### PR TITLE
Update shebang to use env

### DIFF
--- a/dotfiles.sh
+++ b/dotfiles.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Dotfiles management script.  For details, run
 #   $ dotfiles.sh --help


### PR DESCRIPTION
I am trying out `dotfiles.sh` on OS X.  In my setup, I am using `brew` to provide a newer version of `bash`, which is installed to `/usr/local/bin`.  However, `dotfiles.sh` currently looks for `bash` in `/bin`.  This pull request includes a minor proposed change to use `env` to locate `bash`.
